### PR TITLE
Fixes for Rails 4.2 compatibility.

### DIFF
--- a/lib/semantic_attributes/predicates.rb
+++ b/lib/semantic_attributes/predicates.rb
@@ -86,7 +86,7 @@ module SemanticAttributes
       def semantic_attributes=(val)
         @semantic_attributes = val || SemanticAttributes::Set.new
       end
- 
+
       def inherited(klass)
         klass.semantic_attributes = self.semantic_attributes.dup
         super

--- a/semantic_attributes.gemspec
+++ b/semantic_attributes.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "bundler", ">= 1.0.0"
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "rake", ">= 0.8.7"
-  s.add_development_dependency "mocha", ">= 0.10.5"
+  s.add_development_dependency "mocha", ">= 1.2.1"
 
   s.files = `git ls-files`.split("\n")
   s.test_files = `git ls-files -- test/*`.split("\n")

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,8 +1,9 @@
 ENV["RAILS_ENV"] = "test"
 
 # load the support libraries
-require 'minitest/autorun'
 require 'rubygems'
+require "minitest/autorun"
+require "mocha/mini_test"
 require 'active_record'
 require 'active_record/fixtures'
 require 'active_support/time'
@@ -36,6 +37,12 @@ class SemanticAttributes::TestCase < ActiveSupport::TestCase
   self.fixture_path = File.dirname(__FILE__) + '/fixtures/'
 
   fixtures :all
+
+  # >= Rails 4.2
+  if ActiveSupport.respond_to?(:test_order)
+    ActiveSupport.test_order = :random
+  end
+
 end
 
 class ActiveRecord::Base

--- a/test/unit/validations_test.rb
+++ b/test/unit/validations_test.rb
@@ -99,7 +99,7 @@ class ValidationsTest < SemanticAttributes::TestCase
     predicate = @record.semantic_attributes['login'].get('number')
     predicate.expects(:validate).never
 
-    [nil, '', []].each do |empty_value|
+    [nil, ''].each do |empty_value|
       @record.login = empty_value
       assert @record.valid?
     end
@@ -112,7 +112,7 @@ class ValidationsTest < SemanticAttributes::TestCase
     predicate = @record.semantic_attributes['login'].get('number')
     predicate.expects(:validate).never
 
-    [nil, '', []].each do |empty_value|
+    [nil, ''].each do |empty_value|
       @record.login = empty_value
       assert !@record.valid?
       assert @record.errors[:login]


### PR DESCRIPTION
* randomize tests to silence a deprecation message
* stop testing against `[]` for blank (attributes are typecasted before validation in 4.2+)
* fix for case-sensitive uniqueness checks, now that `case_sensitive_equality_operator` is gone. 